### PR TITLE
Fix scraping for 2018 DOM structure

### DIFF
--- a/lib/league.js
+++ b/lib/league.js
@@ -1,7 +1,7 @@
 // League scraper
 var request =  require('request'),
-    cheerio =  require('cheerio'),
-    validate = require('./validate');
+  cheerio =  require('cheerio'),
+  validate = require('./validate');
 
 // Fetch league information
 exports.get = function(leagueType, leagueId, season, callback) {
@@ -30,8 +30,8 @@ exports.get = function(leagueType, leagueId, season, callback) {
     // Extend for the body-left grab of content
     $.prototype.labelSearch = function(children, search) {
       return $(this).find(children).filter(function() {
-        return $(this).text().trim() === search;
-      }).next().text().trim();
+          return $(this).text().trim() === search;
+        }).next().text().trim();
     };
 
     // Get league information
@@ -41,7 +41,7 @@ exports.get = function(leagueType, leagueId, season, callback) {
       commish: $('#body-left .panel-body').labelSearch('dt', 'Commish'),
       type: $('#body-left .panel-body').labelSearch('dt', 'Type'),
       slots: {
-        total: $('.table-group .user-name').length + $('.table-group a.btn-success').length,
+        total: $('.league-name').length,
         available: $('.table-group a.btn-success').length,
         taken: $('.table-group .user-name').length
       },
@@ -54,37 +54,34 @@ exports.get = function(leagueType, leagueId, season, callback) {
       league.stats.push($(this).text());
     });
 
-    // cheerio bug is forces it unable to find tbody for some odd reason
-    for (var i = 0, l = $('.table-group .user-name').length; i < l; i++) {
-      $('#row_0_0_' + i).each(function() {
-        // Only take real teams
-        if ($(this).find('td:first-child .league-name').length > 0) {
-          var team = {
-            name: $(this).find('td:first-child .league-name').text(),
-            rank: $(this).find('td:last-child').text(),
-            points: $(this).find('td:last-child').prev().text(),
-            link: 'https://fleaflicker.com' + $(this).find('td.left .league-name a').attr('href'),
-            id: $(this).find('td:first-child .league-name a').attr('href').match(/\/teams\/(\d{5,7})/)[1],
-            owner: {
-              name: $(this).find('.user-name').text(),
-              link: 'https://fleaflicker.com' + $(this).find('.user-name').attr('href')
-            },
-            stats: {}
-          };
-          var row = $(this);
-          // Push on the stats for the entire team
-          league.stats.forEach(function(stat, index) {
-            team.stats[stat] = {
-              points: parseFloat(row.find('td:nth-child(' + (index + 4) + ')' + ' .text-muted').text()),
-              value: parseFloat(row.find('td:nth-child(' + (index + 4) + ')' + ' .nowrap').text().replace(/,/g, ''))
-            }
-          });
-          league.teams.push(team);
-        }
-      });
-    }
+    $('#body-center-main tr').each(function() {
+      // Only take real teams
+      if ($(this).find('td .league-name').length > 0) {
+        var team = {
+          name: $(this).find('td .league-name').text(),
+          rank: $(this).find('td:nth-child(19)').text(),
+          points: $(this).find('td:nth-child(16)').text(),
+          link: 'https://fleaflicker.com' + $(this).find('td.left .league-name a').attr('href'),
+          id: $(this).find('td .league-name a').attr('href').match(/\/teams\/(\d{5,7})/)[1],
+          owner: {
+            name: $(this).find('.user-name').text(),
+            link: 'https://fleaflicker.com' + $(this).find('.user-name').attr('href')
+          },
+          stats: {}
+        };
+        var row = $(this);
+        // Push on the stats for the entire team
+        league.stats.forEach(function(stat, index) {
+          team.stats[stat] = {
+            points: parseFloat(row.find('td:nth-child(' + (index + 4) + ')' + ' .text-muted').text()),
+            value: parseFloat(row.find('td:nth-child(' + (index + 4) + ')' + ' .nowrap').text().replace(/,/g, ''))
+          }
+        });
+        league.teams.push(team);
+      }
+    });
     return callback(null, league);
 
   });
-
+  
 }

--- a/lib/team.js
+++ b/lib/team.js
@@ -43,20 +43,17 @@ exports.get = function(leagueType, leagueId, teamId, season, callback) {
       points: parseFloat($('#body-left .panel-body').labelSearch('dt', 'Points')),
       players: []
     };
-    // cheerio bug is forces it unable to find tbody for some odd reason
-    for (var i = 0; i < $('#body-center-main .player').length - 1; i++) {
-      $('#row_0_0_' + i).each(function() {
-        // Only take real teams
-        if ($(this).find('td:first-child .player').length > 0) {
-          var player = {
-            name: $(this).find('td .player').text(),
-            totalPoints: parseFloat($(this).find('td .fp').first().text()),
-            avgPoints: parseFloat($(this).find('td .fp').eq(1).text())
-          };
-          team.players.push(player);
-        }
-      });
-    }
+    $('#body-center-main td').each(function() {
+      // Only take real teams
+      if ($(this).find('td:first-child .player').length > 0) {
+        var player = {
+          name: $(this).find('td .player').text(),
+          totalPoints: parseFloat($(this).find('td .fp').first().text()),
+          avgPoints: parseFloat($(this).find('td .fp').eq(1).text())
+        };
+        team.players.push(player);
+      }
+    });
     return callback(null, team);
   });
 

--- a/test/league.spec.js
+++ b/test/league.spec.js
@@ -61,12 +61,13 @@ describe('League scraping', function(){
       // Cant test avail/taken as those slots change and I dont want to mock it
       expect(league.id).to.equal(17027);
       // Cant test individual stats that well
-      expect(league.teams[0].stats.HR.points).to.equal(9);
-      expect(league.teams[0].stats.HR.value).to.equal(204);
-      expect(league.teams[0].stats.ERA.value).to.equal(3.81);
-      expect(league.teams[0].stats.ERA.points).to.equal(6);
-      expect(league.teams[0].stats.QS.value).to.equal(99);
-      expect(league.teams[0].stats.QS.points).to.equal(7.5);
+      expect(league.teams[0].name).to.equal('Mucho Machado Machismo');
+      expect(league.teams[0].stats.HR.points).to.equal(12);
+      expect(league.teams[0].stats.HR.value).to.equal(324);
+      expect(league.teams[0].stats.ERA.value).to.equal(4.06);
+      expect(league.teams[0].stats.ERA.points).to.equal(2);
+      expect(league.teams[0].stats.QS.value).to.equal(84);
+      expect(league.teams[0].stats.QS.points).to.equal(5);
       done();
     });
 


### PR DESCRIPTION
It looks like the DOM structure as well as data used in one of the unit tests have changed.  This PR should resolve those issues.